### PR TITLE
docs(README): delete dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@
   - [Plugins List](https://hexo.io/plugins/) - Whole list of hexo supported plugins
   - Creating Plugins
     - [Develop a plugin for Hexo - Github Card](https://blog.gisonrg.me/2016/04/develop-hexo-github-card/)
-    - [Yeoman based plugin generator](https://github.com/sebs/generator-hexo-plugin)
-    
+
 ## Third-party
 
   - [Hexo Editor](https://github.com/zhuzhuyule/HexoEditor) - Electron based editor for Hexo.
@@ -77,7 +76,6 @@
   - [NexT](https://theme-next.org/) - Hexo theme **NexT** home website. [Theme](https://github.com/theme-next/hexo-theme-next)
   - [Barret Lee](https://www.barretlee.com/) - Barret Lee's personal website. [Source Code](https://github.com/barretlee/blog)
   - [Litten](http://litten.me/) - Hexo theme **Yilia** author Litten's personal blog. [Theme](https://github.com/litten/hexo-theme-yilia)
-  - [Viosey's Blog](https://blog.viosey.com/) - Hexo theme **Material** author Viosey's personal blog. [Theme](https://github.com/viosey/hexo-theme-material)
   - [A list of sites created by Hexo](https://github.com/hexojs/hexo/wiki/Sites) - Hexo wiki
   - [Elements of Programming Interviews](http://elementsofprogramminginterviews.com/) - Book site
   - [Sites using Hexo](https://www.wappalyzer.com/technologies/hexo) - List from Wappalyzer


### PR DESCRIPTION
## Description

Two resources are non-existence.

### generator-hexo-plugin

It seems repository has been deleted. It returns 404.

```sh
$ curl -I https://github.com/sebs/generator-hexo-plugin

HTTP/1.1 404 Not Found
Date: Tue, 20 Aug 2019 13:43:34 GMT
Content-Type: text/html; charset=utf-8
Server: GitHub.com
Status: 404 Not Found
```

### blog.viosey.com

` blog.viosey.com` is `NXDOMAIN` (non-existent domain)

```sh
$ dig blog.viosey.com

; <<>> DiG 9.11.3-1ubuntu1.2-Ubuntu <<>> blog.viosey.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 39547
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;blog.viosey.com.               IN      A

;; AUTHORITY SECTION:
viosey.com.             3474    IN      SOA     anna.ns.cloudflare.com. dns.cloudflare.com. 2031632418 10000 2400 604800 3600

;; Query time: 17 msec
;; SERVER: 192.168.10.1#53(192.168.10.1)
;; WHEN: Tue Aug 20 22:37:12 JST 2019
;; MSG SIZE  rcvd: 103
```